### PR TITLE
Fix float clamping in MecanumDrive

### DIFF
--- a/robot/open-t1/lib/MecanumDrive/src/MecanumDrive.cpp
+++ b/robot/open-t1/lib/MecanumDrive/src/MecanumDrive.cpp
@@ -57,14 +57,15 @@ MecanumDrive::MecanumDrive(SabertoothRC &leftController, SabertoothRC &rightCont
     setMotorSpeed(REAR_LEFT, 0);
     setMotorSpeed(REAR_RIGHT, 0);
 
-    // Set the maximum speed magnitud between -100 and 100
-    maxSpeedMagnitude = Clamp(maxSpeed, -100, 100);
+    // Set the maximum speed magnitude between -100 and 100
+    maxSpeedMagnitude = Clamp(maxSpeed, -100.f, 100.f);
 
 }
 
 void MecanumDrive::setMotorSpeed(MotorIndex motor, int speedPercent)
 {
-    speedPercent = Clamp(speedPercent, -maxSpeedMagnitude, maxSpeedMagnitude);
+    speedPercent = static_cast<int>(
+        Clamp(static_cast<float>(speedPercent), -maxSpeedMagnitude, maxSpeedMagnitude));
     if (motor >= 0 && motor < MOTOR_COUNT)
     {
         SabertoothRC *ctrl = motorMap[motor].controller;
@@ -90,9 +91,12 @@ void MecanumDrive::setMotorSpeed(MotorIndex motor, int speedPercent)
 void MecanumDrive::controlVelocityNormalized(int xPercent, int yPercent, int rotationPercent)
 {
     // Clamp inputs to avoid exceeding your max.
-    xPercent       = Clamp(xPercent, -maxSpeedMagnitude, maxSpeedMagnitude);
-    yPercent       = Clamp(yPercent, -maxSpeedMagnitude, maxSpeedMagnitude);
-    rotationPercent = Clamp(rotationPercent, -maxSpeedMagnitude, maxSpeedMagnitude);
+    xPercent = static_cast<int>(
+        Clamp(static_cast<float>(xPercent), -maxSpeedMagnitude, maxSpeedMagnitude));
+    yPercent = static_cast<int>(
+        Clamp(static_cast<float>(yPercent), -maxSpeedMagnitude, maxSpeedMagnitude));
+    rotationPercent = static_cast<int>(
+        Clamp(static_cast<float>(rotationPercent), -maxSpeedMagnitude, maxSpeedMagnitude));
 
     // -------------------------------------------------------------
     // Standard Mecanum formula (assuming +X=forward, +Y=left, +rot=CCW)

--- a/robot/open-t1/lib/MecanumDrive/src/MecanumDrive.h
+++ b/robot/open-t1/lib/MecanumDrive/src/MecanumDrive.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <array>
+#include <algorithm>
 #include "SabertoothRC.h"
 
 class MecanumDrive
@@ -42,6 +43,12 @@ private:
 
     // Helper to clamp a value between min and max.
     inline int Clamp(int value, int minVal, int maxVal)
+    {
+        return std::max(std::min(value, maxVal), minVal);
+    }
+
+    // Float overload for Clamp
+    inline float Clamp(float value, float minVal, float maxVal)
     {
         return std::max(std::min(value, maxVal), minVal);
     }


### PR DESCRIPTION
## Summary
- use float clamp for maximum speed setup
- add floating point Clamp helper
- correct typo in comment
- clamp int parameters using float range

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ament_* modules)*

------
https://chatgpt.com/codex/tasks/task_e_68666480db848332969c9a01c2ce50fc